### PR TITLE
added interface for query parameter definiton

### DIFF
--- a/definition.go
+++ b/definition.go
@@ -48,6 +48,7 @@ type (
 
 		RequestHeaders  map[string]string
 		ResponseHeaders map[string]string
+		QueryParams     interface{}
 		RequestBody     interface{}
 		ResponseBody    interface{}
 

--- a/definition.go
+++ b/definition.go
@@ -48,9 +48,12 @@ type (
 
 		RequestHeaders  map[string]string
 		ResponseHeaders map[string]string
-		QueryParams     interface{}
-		RequestBody     interface{}
-		ResponseBody    interface{}
+		// InputParams URL Path variables /users/{ID}
+		InputParams interface{}
+		// QueryParams Query string parameters
+		QueryParams  interface{}
+		RequestBody  interface{}
+		ResponseBody interface{}
 
 		Authenticated  bool
 		Authentication string


### PR DESCRIPTION
Allows us to apply an interface definition of the required query string parameters and input parameters.